### PR TITLE
[Feat/#33_canvas-save-toDB] 캔버스 저장 시, 다운로드말구 S3로 보내기

### DIFF
--- a/src/util/canvasToImage.ts
+++ b/src/util/canvasToImage.ts
@@ -1,12 +1,33 @@
 // 캔버스 시안 저장
 
+import axios from 'axios';
+
+const dataURLtoFile = (dataurl: any, filename: any) => {
+  if (dataurl) {
+    const arr = dataurl.split(',');
+    const mime = arr[0].match(/:(.*?);/)[1];
+    const bstr = window.atob(arr[1]);
+    let n = bstr.length;
+    const u8arr = new Uint8Array(n);
+
+    while (n--) {
+      u8arr[n] = bstr.charCodeAt(n);
+    }
+    return new File([u8arr], filename, {
+      type: mime,
+    });
+  }
+};
+
 export const canvasToImage = (canvas: HTMLCanvasElement[]) => {
   if (!window) return;
   canvas.forEach((node, index) => {
     const dataUrl = (node as HTMLCanvasElement).toDataURL('image/png', 1.0);
-    const linkBtn = document.createElement('a');
-    linkBtn.download = `${new Date().toLocaleDateString()}_${index}.png`;
-    linkBtn.href = dataUrl;
-    linkBtn.click();
+    const file = dataURLtoFile(dataUrl, `김창회_${new Date().toLocaleDateString()}_${index}.png`);
+    if (file) {
+      const fd = new FormData();
+      fd.append('image', file);
+      (async () => await axios.post('/post/sample', fd, { baseURL: 'http://localhost:4000' }))();
+    }
   });
 };


### PR DESCRIPTION
추후, 새로 만든 서버에 적용해야함.