### PR TITLE
antd 설정땜시 나는 build 에러 잡기

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,7 +20,7 @@ module.exports = withPlugins(
         },
         webpack(config, { isServer }) {
           if (isServer) {
-            const antStyles = /antd\/.*?\/style.*?/;
+            const antStyles = /(antd\/.*?\/style).*(?<![.]js)$/;
             const origExternals = [...config.externals];
             config.externals = [
               (context, request, callback) => {


### PR DESCRIPTION
```TypeError: (0 , _styleChecker.canUseDocElement) is not a function]```

- antd styleChecker 오류


[참고](https://github.com/vercel/next.js/issues/8151)