### PR TITLE
[Fix/#113_grid] 눈금자 계산 개선

### DIFF
--- a/src/components/tool/divided/DividedTool.tsx
+++ b/src/components/tool/divided/DividedTool.tsx
@@ -473,14 +473,9 @@ const Tool = () => {
   );
 
   const getImgWrapperSizeForParallel = useCallback(() => {
-    const imgWrapper = imgWrapperRef.current;
-    if (!imgWrapper) return;
-    const { width, height } = imgWrapper.getBoundingClientRect();
-    const centerX = width / 2;
-    const centerY = height / 2;
-    setCenterX(centerX);
-    setCenterY(centerY);
-    requestAnimationFrame(() => getImgWrapperSizeForParallel);
+    const { innerWidth: width, innerHeight: height } = window;
+    setCenterX(width / 2);
+    setCenterY((height - HEADER_HEIGHT) / 2);
   }, [setCenterX, setCenterY]);
 
   // 리사이즈시에도 동일하게 움직일 수 있도록 설정
@@ -562,8 +557,6 @@ const Tool = () => {
   }, [imgUploadUrl, setOriginHeight, setOriginWidth, setResizeHeight, setResizeWidth]);
 
   useEffect(() => {
-    const imgWrapper = imgWrapperRef.current;
-    if (!imgWrapper) return;
     if (isGridGuideLine) {
       setGridWidth(
         Math.floor(window.innerWidth / 36) % 2 === 0
@@ -602,8 +595,6 @@ const Tool = () => {
 
   // 정가운데값 구하기
   useEffect(() => {
-    const imgWrapper = imgWrapperRef.current;
-    if (!imgWrapper) return;
     const { innerWidth: width, innerHeight: height } = window;
     setCenterX(width / 2);
     setCenterY((height - HEADER_HEIGHT) / 2);


### PR DESCRIPTION
1. 이유
- 헤더의 크기 고려를 하지 않음
- 그리드의 시작점이 0px부터 시작이었음. (위와 같은 맥락임)

2. 해결
- 헤더의 크기(현 86px) 마이너스

3. 그외
- imgWrapper의 크기, 높이로 계산했는데, window의 innerWidth로 재계산. 계산은 상관이 없는걸로 판명