### PR TITLE
[Fix/expand] 옆면 cm 이슈 수정

### DIFF
--- a/src/utils/createExpandSave.ts
+++ b/src/utils/createExpandSave.ts
@@ -164,7 +164,6 @@ export const createExpandCanvas = (selectedFrame: SelectedFrame[], expandType: 1
         ctx.globalCompositeOperation = 'destination-over';
         ctx.fillStyle = info.bgColor || '#fff';
         ctx.fillRect(0, 0, canvasFrameWidth, canvasFrameHeight);
-        document.body.appendChild(canvas);
       }
     };
   });


### PR DESCRIPTION
- 선택한 액자의 사이즈를 조절하게 되면서 옆면확장된 cm가 4cm로 고정된게 아닌, 가변적으로 변하는 걸 목격..
- 예를들면 14x18cm짜리 f0호를 사용한 경우 14x18의 비율에 맞춰 상하좌우 4cm 씩을 계산한게 아닌, 가변된 액자 사이즈를 토대로 상하좌우를 계산하려다 보니 착오가 생겼음.

- 그래서 기존 액자 사이즈에 맞춰 이미지의 크기를 맞추고, 폭이 14cm면, 딱 14센티 + 양옆 4센티씩 총 18cm가 이미지로 만들어지게 수정.
- 나중에 cm 수정할때를 대비해서 cm 변수도 추가.